### PR TITLE
[fix] fix a scroll to top bug

### DIFF
--- a/BHInfiniteScrollView/BHInfiniteScrollView/BHInfiniteScrollView.m
+++ b/BHInfiniteScrollView/BHInfiniteScrollView/BHInfiniteScrollView.m
@@ -549,6 +549,7 @@
         
         _collectionView = [[UICollectionView alloc]initWithFrame:self.bounds collectionViewLayout:flowLayout];
         _collectionView.pagingEnabled = YES;
+        _collectionView.scrollsToTop = NO;
         _collectionView.showsHorizontalScrollIndicator = NO;
         _collectionView.showsVerticalScrollIndicator = NO;
         _collectionView.backgroundColor = [UIColor clearColor];


### PR DESCRIPTION
if InfiniteScrollView is using in another scrollview , neither of them will response to scrollToTop property. This will be common as using InfiniteScrollView as banner view. so I just disable the collectionView's scrollToView property. Also can add a property in BHInfiniteScrollView.h to let user custom this property.
